### PR TITLE
From env read git author

### DIFF
--- a/makefile
+++ b/makefile
@@ -26,5 +26,4 @@ publish: fmt
 	$(c) publish -v
 
 .PHONY: commit
-commit: fmt test
-	$(g) -a .
+commit: fmt test run

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -9,6 +9,9 @@ pub const SEPARATOR_SYMBOL: &str = ":";
 
 pub const SPACE: &str = " ";
 
+pub const GIT_AUTHOR_NAME: &str = "GIT_AUTHOR_NAME";
+pub const GIT_AUTHOR_EMAIL: &str = "GIT_AUTHOR_EMAIL";
+
 pub const GLOBAL_CONFIG_PATH: &str = ".config/grc/grc.toml";
 
 pub const BASE_COMMIT_TYPE_DESCRIPTION: &[(&str, &str)] = &[

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2,9 +2,13 @@ use git2::{
     Commit, Error, Index, IndexAddOption, ObjectType, Repository as GRepository, Signature,
     StatusOptions, Statuses,
 };
+use std::env;
 
-use crate::{arguments::Arguments, metadata::Mode, util::is_all_workspace};
-
+use crate::{
+    arguments::Arguments,
+    metadata::Mode,
+    util::{git_sign_from_env, is_all_workspace},
+};
 // Repository in GRC.
 // is git2::Repository Encapsulation.
 pub struct Repository {
@@ -49,7 +53,6 @@ impl Repository {
 
     // execute git commit.
     pub fn commit(&self, message: &str) -> Result<(), Error> {
-        let current_sign = self.generate_sign();
         let tree_id = {
             let mut index = self.repo.index()?;
             index.write_tree()?
@@ -57,6 +60,14 @@ impl Repository {
 
         let tree = self.repo.find_tree(tree_id)?;
         let commit = self.find_last_commit()?;
+
+        let current_sign = match self.generate_sign() {
+            Ok(sign) => sign,
+            Err(_) => match git_sign_from_env() {
+                Ok(sign) => sign,
+                Err(e) => return Err(e),
+            },
+        };
 
         self.repo.commit(Some("HEAD"), &current_sign, &current_sign, message, &tree, &[&commit])?;
 
@@ -92,9 +103,9 @@ impl Repository {
         Ok(())
     }
 
-    // get sigin(email, authot ... ) from git config.
-    fn generate_sign(&self) -> Signature<'static> {
-        self.repo.signature().unwrap()
+    // get sigin(email, author ... ) from git config.
+    fn generate_sign(&self) -> Result<Signature<'static>, Error> {
+        self.repo.signature()
     }
 
     // the last commit in this repository.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,7 @@
-use git2::{Status, Statuses};
-use std::fs;
+use git2::{Error, Signature, Status, Statuses};
+use std::{env, fs};
+
+use crate::metadata::{GIT_AUTHOR_EMAIL, GIT_AUTHOR_NAME};
 
 pub fn current_path() -> String {
     let path = fs::canonicalize(".").unwrap();
@@ -40,6 +42,21 @@ pub fn vec_str_to_string(vec: Vec<&str>) -> Vec<String> {
         result.push(String::from(s));
     }
     result
+}
+
+pub fn git_sign_from_env() -> Result<Signature<'static>, Error> {
+    let username = match env::var(GIT_AUTHOR_NAME) {
+        Ok(v) => v,
+        Err(e) => return Err(Error::from_str(e.to_string().as_str())),
+    };
+
+    let email = match env::var(GIT_AUTHOR_EMAIL) {
+        Ok(v) => v,
+        Err(e) => return Err(Error::from_str(e.to_string().as_str())),
+    };
+
+    let sign = Signature::now(username.as_str(), email.as_str())?;
+    Ok(sign)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Now, If the user information cannot be read in the repo config, GRC will read it from the **environment** variable.

Fixes #30 