### PR TITLE
To version 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 *.sh
 *.exe
+*.7z

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "grc"
-version = "0.9.2"
+version = "1.0.0"
 dependencies = [
  "cargo-husky",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grc"
-version = "0.9.2"
+version = "1.0.0"
 authors = ["sdttttt <sdttttt@outlook.com>"]
 description = "Similar to git-cz, gcr will help you to provide a better Git experience."
 readme = "README.md"

--- a/grc.toml
+++ b/grc.toml
@@ -1,1 +1,2 @@
+emoji = true
 type = ["version: version is change.", "deps: Dependencies change."]

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -28,8 +28,8 @@ impl Arguments {
 		&self.config_filename.as_str()
 	}
 
-	pub fn command_mode(&self) -> &Mode {
-		&self.mode
+	pub fn command_mode(&self) -> Mode {
+		self.mode.clone()
 	}
 
 	pub fn files(&self) -> &Vec<String> {
@@ -177,19 +177,19 @@ mod tests {
 	fn add_all_mode() {
 		let args = quick_command_run(vec!["grc", "--add", "."]);
 
-		assert_eq!(args.command_mode(), &Mode::AddAll);
+		assert_eq!(args.command_mode(), Mode::AddAll);
 	}
 
 	#[test]
 	fn add_mode() {
 		let args = quick_command_run(vec!["grc", "--add", "rusty"]);
-		assert_eq!(args.command_mode(), &Mode::Add);
+		assert_eq!(args.command_mode(), Mode::Add);
 	}
 
 	#[test]
 	fn commit_mode() {
 		let args = quick_command_run(vec!["grc"]);
-		assert_eq!(args.command_mode(), &Mode::Commit);
+		assert_eq!(args.command_mode(), Mode::Commit);
 	}
 
 	#[test]

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -9,6 +9,7 @@ pub struct Arguments {
 	mode:            Mode,
 	params:          Vec<String>,
 	config_filename: String,
+	emoji:           bool,
 }
 
 // Get the external parameter and analyze it. Construct the behavior of GRC.
@@ -35,20 +36,25 @@ impl Arguments {
 		&self.params
 	}
 
-	fn default() -> Self {
+	pub fn emoji(&self) -> bool {
+		self.emoji
+	}
+
+	pub fn default() -> Self {
 		Self {
 			mode:            Mode::Commit,
 			params:          vec![],
 			config_filename: String::new(),
+			emoji:           false,
 		}
 	}
 
 	fn cli() -> App<'static, 'static> {
-		App::new(NAME)
-			.version(VERSION)
-			.author(AUTHOR)
-			.about(DESCRIPTION)
-			.args(&[Self::add_arg(), Self::designate_config_arg()])
+		App::new(NAME).version(VERSION).author(AUTHOR).about(DESCRIPTION).args(&[
+			Self::add_arg(),
+			Self::designate_config_arg(),
+			Self::emoji_arg(),
+		])
 	}
 
 	fn add_arg() -> Arg<'static, 'static> {
@@ -70,6 +76,14 @@ impl Arguments {
 			.takes_value(true)
 	}
 
+	fn emoji_arg() -> Arg<'static, 'static> {
+		Arg::with_name(EMOJI_COMMAND)
+			.long(EMOJI_COMMAND)
+			.required(false)
+			.help(EMOJI_COMMAND_HELP)
+			.takes_value(false)
+	}
+
 	/// Construct the behavior according to the input parameters.
 	fn resolve_command(matches: ArgMatches) -> Result<Self, Error> {
 		let mut arg = Self::default();
@@ -84,7 +98,7 @@ impl Arguments {
 		// extend-handle: fn(&mut Arguments, &ArgMatches) -> Result<bool, Error>
 		// extended GRC parameters will be handled here. They are processed before the
 		// final behavior is determined.
-		let before_handles = &[Self::designate_config_handle];
+		let before_handles = &[Self::designate_config_handle, Self::emoji_check_handle];
 
 		for handle in before_handles {
 			handle(arg, matches)?;
@@ -104,11 +118,18 @@ impl Arguments {
 		Ok(false)
 	}
 
+	fn emoji_check_handle(arg: &mut Arguments, matches: &ArgMatches) -> Result<bool, Error> {
+		if matches.is_present(EMOJI_COMMAND) {
+			arg.emoji = true;
+			return Ok(true);
+		}
+		return Ok(false);
+	}
+
 	fn finally_handle_chain(arg: &mut Arguments, matches: &ArgMatches) -> Result<bool, Error> {
 		// finally-handle: fn(&mut Arguments, &ArgMatches) -> Result<bool, Error>
 		// that confirm the behavior to be finally used by the GRC and the required
-		// parameters. This is a chain of responsibility where only one processor will
-		// receive the job.
+		// parameters. This is a chain of responsibility
 		let post_handles = &[Self::add_params_handle];
 
 		for handle in post_handles {

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -187,6 +187,12 @@ mod tests {
 	}
 
 	#[test]
+	fn enable_emoji() {
+		let args = quick_command_run(vec!["grc", "--emoji"]);
+		assert!(args.emoji())
+	}
+
+	#[test]
 	fn commit_mode() {
 		let args = quick_command_run(vec!["grc"]);
 		assert_eq!(args.command_mode(), Mode::Commit);

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,14 +16,7 @@ impl Configuration {
 		let params = arg.files().clone();
 		let extends_type = ext.types().clone();
 		let mode = arg.command_mode();
-
-		let emoji = {
-			if ext.emoji() || arg.emoji() {
-				ext.emoji()
-			} else {
-				false
-			}
-		};
+		let emoji = ext.emoji() || arg.emoji();
 
 		Rc::new(Self { params, extends_type, emoji, mode })
 	}

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ pub struct Configuration {
 impl Configuration {
 	pub fn merge(arg: Arguments, ext: Extensions) -> Rc<Self> {
 		let params = arg.files().clone();
-		let extends_type = ext.types().clone();
+		let extends_type = ext.types().unwrap_or(&vec![]).clone();
 		let mode = arg.command_mode();
 		let emoji = ext.emoji() || arg.emoji();
 		let overwrite_emoji =

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,10 +5,11 @@ use crate::{arguments::Arguments, extensions::Extensions, metadata::Mode};
 // Both command-line arguments and configuration files can specify configuration
 // options, and the two are combined here.
 pub struct Configuration {
-	mode:         Mode,
-	extends_type: Vec<String>,
-	params:       Vec<String>,
-	emoji:        bool,
+	mode:            Mode,
+	extends_type:    Vec<String>,
+	params:          Vec<String>,
+	overwrite_emoji: Vec<String>,
+	emoji:           bool,
 }
 
 impl Configuration {
@@ -17,17 +18,19 @@ impl Configuration {
 		let extends_type = ext.types().clone();
 		let mode = arg.command_mode();
 		let emoji = ext.emoji() || arg.emoji();
+		let overwrite_emoji =
+			if emoji { ext.overwrite_emoji().unwrap_or(&vec![]).clone() } else { vec![] };
 
-		Rc::new(Self { params, extends_type, emoji, mode })
+		Rc::new(Self { params, extends_type, emoji, mode, overwrite_emoji })
 	}
 
-	#[cfg(test)]
-	pub fn default() -> Rc<Self> {
-		let ext = Extensions::from_agreement().unwrap();
-		let arg = Arguments::default();
+	//#[cfg(test)]
+	//pub fn default() -> Rc<Self> {
+	//	let ext = Extensions::from_agreement().unwrap();
+	//	let arg = Arguments::default();
 
-		Self::merge(arg, ext)
-	}
+	//	Self::merge(arg, ext)
+	//}
 
 	pub fn command_mode(&self) -> &Mode {
 		&self.mode
@@ -43,5 +46,9 @@ impl Configuration {
 
 	pub fn emoji(&self) -> bool {
 		self.emoji
+	}
+
+	pub fn overwrite_emoji(&self) -> &Vec<String> {
+		&self.overwrite_emoji
 	}
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,40 @@
+use std::rc::Rc;
+
+use crate::{arguments::Arguments, extensions::Extensions};
+// Both command-line arguments and configuration files can specify configuration
+// options, and the two are combined here.
+pub struct Configuration {
+	extends_type: Vec<String>,
+	params: Vec<String>,
+	emoji: bool,
+}
+
+impl Configuration {
+	pub fn merge(arg: Arguments, ext: Extensions) -> Rc<Self> {
+
+		let params = arg.files().clone();
+		let extends_type = ext.types().clone();
+
+		let emoji = {
+			if ext.emoji() || arg.emoji() {
+				ext.emoji()
+			} else {
+				false
+			}
+		};
+
+		Rc::new(Self { params, extends_type,emoji })
+	}
+
+	pub fn extends_type(&self) -> &Vec<String> {
+		&self.extends_type
+	}
+
+	pub fn files(&self) ->  &Vec<String> {
+		&self.params
+	}
+
+	pub fn emoji(&self) -> bool {
+		self.emoji
+	}
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,19 +1,21 @@
 use std::rc::Rc;
 
-use crate::{arguments::Arguments, extensions::Extensions};
+use crate::{arguments::Arguments, extensions::Extensions, metadata::Mode};
+
 // Both command-line arguments and configuration files can specify configuration
 // options, and the two are combined here.
 pub struct Configuration {
+	mode:         Mode,
 	extends_type: Vec<String>,
-	params: Vec<String>,
-	emoji: bool,
+	params:       Vec<String>,
+	emoji:        bool,
 }
 
 impl Configuration {
 	pub fn merge(arg: Arguments, ext: Extensions) -> Rc<Self> {
-
 		let params = arg.files().clone();
 		let extends_type = ext.types().clone();
+		let mode = arg.command_mode();
 
 		let emoji = {
 			if ext.emoji() || arg.emoji() {
@@ -23,14 +25,26 @@ impl Configuration {
 			}
 		};
 
-		Rc::new(Self { params, extends_type,emoji })
+		Rc::new(Self { params, extends_type, emoji, mode })
+	}
+
+	#[cfg(test)]
+	pub fn default() -> Rc<Self> {
+		let ext = Extensions::from_agreement().unwrap();
+		let arg = Arguments::default();
+
+		Self::merge(arg, ext)
+	}
+
+	pub fn command_mode(&self) -> &Mode {
+		&self.mode
 	}
 
 	pub fn extends_type(&self) -> &Vec<String> {
 		&self.extends_type
 	}
 
-	pub fn files(&self) ->  &Vec<String> {
+	pub fn files(&self) -> &Vec<String> {
 		&self.params
 	}
 

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -12,8 +12,7 @@ pub struct Extensions {
 	#[serde(rename = "type")]
 	typ: Vec<String>,
 
-	#[serde(rename = "emoji")]
-	emoji: bool,
+	emoji: Option<bool>,
 }
 
 impl Extensions {
@@ -53,13 +52,13 @@ impl Extensions {
 	}
 
 	pub fn emoji(&self) -> bool {
-		self.emoji
+		self.emoji.unwrap_or_else(|| false)
 	}
 
 	/// deserialize toml configuration file to struct.
 	fn deserialize(file_str: String) -> Result<Self, Error> {
 		if file_str.len() == 0 || file_str == "" {
-			return Ok(Self { typ: vec![], emoji: false });
+			return Ok(Self { typ: vec![], emoji: None });
 		}
 
 		let config = toml::from_str::<Extensions>(file_str.as_str())?;
@@ -89,8 +88,11 @@ mod tests {
 	const GRC_TEST_CONFIG_FILE_NAME: &str = "grc.test.toml";
 
 	const GRC_TOML_CONTENT: &str =
-		r#"type = ["version: version is change.", "deps: Dependencies change."]"#;
+		r#"emoji = true
+type = ["version: version is change.", "deps: Dependencies change."]"#;
+
 	const GRC_TOML_TYPE: &str = "version: version is change.";
+	const GRC_TOML_EMOJI: Option<bool> = Some(true);
 
 	const GRC_TEST_TOML_CONTENT: &str = r#"type = [ "123" ]"#;
 	const GRC_TEST_TOML_TYPE: &str = "123";
@@ -114,7 +116,9 @@ mod tests {
 		let result = Extensions::deserialize(file_str).unwrap();
 
 		let types = result.typ;
+		let emoji = result.emoji;
 		assert_eq!(types[0], GRC_TOML_TYPE);
+		assert_eq!(emoji, GRC_TOML_EMOJI);
 	}
 
 	#[test]

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -98,7 +98,7 @@ mod tests {
 		let file_str = Extensions::read_config_file(GRC_TEST_CONFIG_FILE_NAME).unwrap();
 		assert_eq!(file_str.as_str(), GRC_TEST_TOML_CONTENT);
 
-		let file_str2 = Extensions::read_config_file("nullfile").unwrap();
+		let file_str2 = Extensions::read_config_file("null_file").unwrap();
 		assert_eq!(file_str2.len(), 0);
 		assert_eq!(file_str2.as_str(), "");
 

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -13,6 +13,8 @@ pub struct Extensions {
 	typ: Vec<String>,
 
 	emoji: Option<bool>,
+
+	overwrite_emoji: Option<Vec<String>>,
 }
 
 impl Extensions {
@@ -55,10 +57,18 @@ impl Extensions {
 		self.emoji.unwrap_or_else(|| false)
 	}
 
+	pub fn overwrite_emoji(&self) -> Option<&Vec<String>> {
+		self.overwrite_emoji.as_ref()
+	}
+
 	/// deserialize toml configuration file to struct.
 	fn deserialize(file_str: String) -> Result<Self, Error> {
 		if file_str.len() == 0 || file_str == "" {
-			return Ok(Self { typ: vec![], emoji: None });
+			return Ok(Self {
+				typ:             vec![],
+				emoji:           None,
+				overwrite_emoji: None,
+			});
 		}
 
 		let config = toml::from_str::<Extensions>(file_str.as_str())?;

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -10,7 +10,7 @@ use crate::metadata::{GLOBAL_CONFIG_PATH, GRC_CONFIG_FILE_NAME};
 #[derive(Deserialize)]
 pub struct Extensions {
 	#[serde(rename = "type")]
-	typ: Vec<String>,
+	typ: Option<Vec<String>>,
 
 	emoji: Option<bool>,
 
@@ -49,8 +49,8 @@ impl Extensions {
 	}
 
 	/// got All Types in configuration file.
-	pub fn types(&self) -> &Vec<String> {
-		&self.typ
+	pub fn types(&self) -> Option<&Vec<String>> {
+		self.typ.as_ref()
 	}
 
 	pub fn emoji(&self) -> bool {
@@ -65,7 +65,7 @@ impl Extensions {
 	fn deserialize(file_str: String) -> Result<Self, Error> {
 		if file_str.len() == 0 || file_str == "" {
 			return Ok(Self {
-				typ:             vec![],
+				typ:             None,
 				emoji:           None,
 				overwrite_emoji: None,
 			});
@@ -121,7 +121,7 @@ mod tests {
 		let config = Extensions::read_config_file(GRC_CONFIG_FILE_NAME).unwrap();
 		let result = Extensions::deserialize(config).unwrap();
 
-		let types = result.typ;
+		let types = result.typ.unwrap();
 		let emoji = result.emoji;
 		assert_eq!(types[0], GRC_TOML_TYPE);
 		assert_eq!(emoji, GRC_TOML_EMOJI);
@@ -130,7 +130,7 @@ mod tests {
 	#[test]
 	fn it_from_agreement() {
 		let config = Extensions::from_agreement().unwrap();
-		let types = config.typ;
+		let types = config.typ.unwrap();
 
 		assert_eq!(types[0], GRC_TOML_TYPE);
 	}
@@ -138,7 +138,7 @@ mod tests {
 	#[test]
 	fn it_from() {
 		let config = Extensions::from(GRC_TEST_CONFIG_FILE_NAME).unwrap();
-		let types = config.typ;
+		let types = config.typ.unwrap();
 
 		assert_eq!(types[0], GRC_TEST_TOML_TYPE);
 	}

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -87,8 +87,7 @@ mod tests {
 
 	const GRC_TEST_CONFIG_FILE_NAME: &str = "grc.test.toml";
 
-	const GRC_TOML_CONTENT: &str =
-		r#"emoji = true
+	const GRC_TOML_CONTENT: &str = r#"emoji = true
 type = ["version: version is change.", "deps: Dependencies change."]"#;
 
 	const GRC_TOML_TYPE: &str = "version: version is change.";

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -87,9 +87,6 @@ mod tests {
 
 	const GRC_TEST_CONFIG_FILE_NAME: &str = "grc.test.toml";
 
-	const GRC_TOML_CONTENT: &str = r#"emoji = true
-type = ["version: version is change.", "deps: Dependencies change."]"#;
-
 	const GRC_TOML_TYPE: &str = "version: version is change.";
 	const GRC_TOML_EMOJI: Option<bool> = Some(true);
 
@@ -106,13 +103,13 @@ type = ["version: version is change.", "deps: Dependencies change."]"#;
 		assert_eq!(file_str2.as_str(), "");
 
 		let config = Extensions::read_config_file(GRC_CONFIG_FILE_NAME).unwrap();
-		assert_eq!(config.as_str(), GRC_TOML_CONTENT);
+		assert!(config.len() > 0);
 	}
 
 	#[test]
 	fn it_deserialize() {
-		let file_str = String::from(GRC_TOML_CONTENT);
-		let result = Extensions::deserialize(file_str).unwrap();
+		let config = Extensions::read_config_file(GRC_CONFIG_FILE_NAME).unwrap();
+		let result = Extensions::deserialize(config).unwrap();
 
 		let types = result.typ;
 		let emoji = result.emoji;

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -11,6 +11,9 @@ use crate::metadata::{GLOBAL_CONFIG_PATH, GRC_CONFIG_FILE_NAME};
 pub struct Extensions {
 	#[serde(rename = "type")]
 	typ: Vec<String>,
+
+	#[serde(rename = "emoji")]
+	emoji: bool,
 }
 
 impl Extensions {
@@ -49,10 +52,14 @@ impl Extensions {
 		&self.typ
 	}
 
+	pub fn emoji(&self) -> bool {
+		self.emoji
+	}
+
 	/// deserialize toml configuration file to struct.
 	fn deserialize(file_str: String) -> Result<Self, Error> {
 		if file_str.len() == 0 || file_str == "" {
-			return Ok(Self { typ: vec![] });
+			return Ok(Self { typ: vec![], emoji: false });
 		}
 
 		let config = toml::from_str::<Extensions>(file_str.as_str())?;

--- a/src/log.rs
+++ b/src/log.rs
@@ -16,12 +16,12 @@ pub fn grc_err_println(content: impl Display) {
 }
 
 /// GCR error logger.
-pub fn grc_warn_println(content: impl Display) {
-	let color = Style::new().yellow();
-	let output = format!("GRC: {}", content);
+//pub fn grc_warn_println(content: impl Display) {
+//	let color = Style::new().yellow();
+//	let output = format!("GRC: {}", content);
 
-	println!("{}", color.apply_to(output))
-}
+//	println!("{}", color.apply_to(output))
+//}
 
 #[cfg(test)]
 mod tests {

--- a/src/log.rs
+++ b/src/log.rs
@@ -37,9 +37,4 @@ mod tests {
 	fn it_grc_err_println() {
 		grc_err_println("TEST ERROR CONTENT.");
 	}
-
-	#[test]
-	fn it_grc_warn_println() {
-		grc_warn_println("TEST WARN CONTENT.");
-	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,8 +55,12 @@ fn main() {
 	};
 
 	// commit message.
-	let message =
-		Messager::new(Rc::clone(&config)).load_ext_td(&config.extends_type()).ask().build();
+	let message = Messager::new(config.emoji())
+		.load_ext_td(&config.extends_type())
+		.load_ext_emoji(&config.overwrite_emoji())
+		.ask()
+		.build();
+
 	grc_println(&message);
 
 	// Git commit

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use std::rc::Rc;
 
 mod arguments;
-mod extensions;
 mod config;
+mod extensions;
 mod log;
 mod message;
 mod metadata;
@@ -26,14 +26,14 @@ fn main() {
 			return;
 		}
 	};
-	
+
 	// parse configuration file to Extensions struct.
 	let ext = if arg.has_specified_config() {
 		Extensions::from(arg.config_file())
 	} else {
 		Extensions::from_agreement()
 	};
-	
+
 	let extensions = match ext {
 		| Ok(e) => e,
 		| Err(e) => {
@@ -43,7 +43,7 @@ fn main() {
 	};
 
 	let config = Configuration::merge(arg, extensions);
-	
+
 	let path = current_path();
 	// repository Object instance.
 	let repo = match Repository::new(path, Rc::clone(&config)) {
@@ -55,7 +55,8 @@ fn main() {
 	};
 
 	// commit message.
-	let message = Messager::new(Rc::clone(&config)).load_ext_td(&config.extends_type()).ask().build();
+	let message =
+		Messager::new(Rc::clone(&config)).load_ext_td(&config.extends_type()).ask().build();
 	grc_println(&message);
 
 	// Git commit

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,12 +26,13 @@ fn main() {
 			return;
 		}
 	};
+	
 	// parse configuration file to Extensions struct.
 	let ext = if arg.has_specified_config() {
 		Extensions::from(arg.config_file())
 	} else {
 		Extensions::from_agreement()
-	}
+	};
 	
 	let extensions = match ext {
 		| Ok(e) => e,
@@ -43,12 +44,9 @@ fn main() {
 
 	let config = Configuration::merge(arg, extensions);
 	
-	// extends types.
-	let mut types: Vec<String> = vec![];
-	
 	let path = current_path();
 	// repository Object instance.
-	let repo = match Repository::new(path, Rc::clone(&arg)) {
+	let repo = match Repository::new(path, Rc::clone(&config)) {
 		| Ok(r) => r,
 		| Err(e) => {
 			grc_err_println(e.message());
@@ -57,7 +55,7 @@ fn main() {
 	};
 
 	// commit message.
-	let message = Messager::new(Rc::clone(&arg)).load_ext_td(&types).ask().build();
+	let message = Messager::new(Rc::clone(&config)).load_ext_td(&config.extends_type()).ask().build();
 	grc_println(&message);
 
 	// Git commit

--- a/src/message.rs
+++ b/src/message.rs
@@ -139,7 +139,7 @@ impl Messager {
 		// Custom TYPE.
 		if selection == self.commit_type_descript.len() - 1 {
 			self.typ = Input::with_theme(&ColorfulTheme::default())
-				.with_prompt("GRC: What Type ?")
+				.with_prompt("What Type ?")
 				.validate_with(|input: &String| -> Result<(), &str> {
 					if input.len() == 0 || input.trim().len() == 0 {
 						Err("(ﾟДﾟ*)ﾉPlease do not enter empty string.")
@@ -163,7 +163,7 @@ impl Messager {
 	/// scope of commit message.
 	fn ask_scope(&mut self) {
 		let scope = Input::<String>::with_theme(&ColorfulTheme::default())
-			.with_prompt("GRC: Which scope? (Optional)")
+			.with_prompt("Which scope? (Optional)")
 			.allow_empty(true)
 			.interact()
 			.unwrap();
@@ -174,7 +174,7 @@ impl Messager {
 	/// subject of commit message.
 	fn ask_subject(&mut self) {
 		self.subject = Input::<String>::with_theme(&ColorfulTheme::default())
-			.with_prompt("GRC: Commit Message ?")
+			.with_prompt("Commit Message ?")
 			.validate_with(|input: &String| -> Result<(), &str> {
 				if input.len() == 0 || input.trim().len() == 0 {
 					Err("(ﾟДﾟ*)ﾉPlease do not enter empty string.")
@@ -185,13 +185,13 @@ impl Messager {
 			.interact()
 			.unwrap();
 
-		self.subject = format!("{}{}", self.emoji, self.subject)
+		self.subject = format!("{} {}", self.emoji, self.subject)
 	}
 
 	/// description of commit message.
 	fn ask_description(&self) -> String {
 		let description = Input::<String>::with_theme(&ColorfulTheme::default())
-			.with_prompt("GRC: Provide a longer description? (Optional)")
+			.with_prompt("Provide a longer description? (Optional)")
 			.allow_empty(true)
 			.interact()
 			.unwrap();
@@ -202,7 +202,7 @@ impl Messager {
 	/// close PR or issue of commit message.
 	fn ask_close(&self) -> String {
 		let closes = Input::<String>::with_theme(&ColorfulTheme::default())
-			.with_prompt("GRC: PR & Issues this commit closes, e.g 123: (Optional)")
+			.with_prompt("PR & Issues this commit closes, e.g 123: (Optional)")
 			.allow_empty(true)
 			.interact()
 			.unwrap();

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,5 +1,7 @@
 use dialoguer::{theme::ColorfulTheme, Input, Select};
+use std::rc::Rc;
 
+use crate::arguments::Arguments;
 use crate::log::grc_err_println;
 use crate::metadata::*;
 use crate::util::remove_pound_prefix;
@@ -8,6 +10,7 @@ struct CommitTD(String, String);
 
 /// Messsager is Commit Message struct.
 pub struct Messager {
+	arg:                  Rc<Arguments>,
 	commit_type_descript: Vec<CommitTD>,
 
 	typ:     String,
@@ -23,7 +26,7 @@ impl CommitTD {
 }
 
 impl Messager {
-	pub fn new() -> Self {
+	pub fn new(arg: Rc<Arguments>) -> Self {
 		let commit_type_descript = BASE_COMMIT_TYPE_DESCRIPTION
 			.iter()
 			.map(|td: &(&str, &str)| CommitTD::from(td.0, td.1))
@@ -33,7 +36,7 @@ impl Messager {
 		let subject = String::new();
 		let body = String::new();
 
-		Self { commit_type_descript, typ, scope, subject, body }
+		Self { arg, commit_type_descript, typ, scope, subject, body }
 	}
 
 	/// Load externally provided extension types.
@@ -149,7 +152,16 @@ impl Messager {
 				}
 			})
 			.interact()
-			.unwrap()
+			.unwrap();
+
+		if self.arg.emoji() {
+			for emoji in BASE_COMMIT_TYPE_EMOJI {
+				if self.typ.as_str() == emoji.0 {
+					self.subject = format!("{}{}", emoji.1, self.subject);
+					break;
+				}
+			}
+		}
 	}
 
 	/// description of commit message.
@@ -198,12 +210,21 @@ mod tests {
 
 	#[test]
 	fn it_type_list() {
-		let tl = Messager::new().type_list();
+		let arg = Rc::new(Arguments::default());
+		let tl = Messager::new(Rc::clone(&arg)).type_list();
 		assert_eq!(tl[0].as_str(), "test:       Adding missing tests.");
 		assert_eq!(tl[1].as_str(), "feat:       A new feature.");
 		assert_eq!(tl[2].as_str(), "fix:        A bug fix.");
-		assert_eq!(tl[3].as_str(), "chore:      Build process or auxiliary tool changes.");
-		assert_eq!(tl[4].as_str(), "docs:       Documentation only changes.");
+		assert_eq!(
+			tl[3].as_str(),
+			"chore:      Build process or auxiliary tool
+	 changes."
+		);
+		assert_eq!(
+			tl[4].as_str(),
+			"docs:       Documentation only
+	 changes."
+		);
 		assert_eq!(
 			tl[5].as_str(),
 			"refactor:   A code change that neither fixes a bug or adds a feature."
@@ -212,20 +233,38 @@ mod tests {
 			tl[6].as_str(),
 			"style:      Markup, white-space, formatting, missing semi-colons..."
 		);
-		assert_eq!(tl[7].as_str(), "perf:       A code change that improves performance.");
-		assert_eq!(tl[8].as_str(), "ci:         CI related changes.");
+		assert_eq!(
+			tl[7].as_str(),
+			"perf:       A code change that improves
+	 performance."
+		);
+		assert_eq!(
+			tl[8].as_str(),
+			"ci:         CI related
+	 changes."
+		);
 	}
 
 	#[test]
 	fn it_load_ext_td() {
-		let tl =
-			Messager::new().load_ext_td(&vec!["this: yes, like this.".to_string()]).type_list();
-		assert_eq!(tl[9].as_str(), "this:       yes, like this.")
+		let arg = Rc::new(Arguments::default());
+		let tl = Messager::new(Rc::clone(&arg))
+			.load_ext_td(&vec!["this: yes, like
+	 this."
+				.to_string()])
+			.type_list();
+		assert_eq!(
+			tl[9].as_str(),
+			"this:
+	 yes, like this."
+		)
 	}
 
 	#[test]
 	fn it_build() {
-		let mut message = Messager::new();
+		let arg = Rc::new(Arguments::default());
+
+		let mut message = Messager::new(Rc::clone(&arg));
 		message.typ = "type".to_string();
 		message.scope = "scope".to_string();
 		message.subject = "subject.".to_string();

--- a/src/message.rs
+++ b/src/message.rs
@@ -11,7 +11,6 @@ struct CommitTD(String, String, String);
 
 /// Messsager is Commit Message struct.
 pub struct Messager {
-	config:               Rc<Configuration>,
 	commit_type_descript: Vec<CommitTD>,
 
 	typ:     String,
@@ -62,7 +61,7 @@ impl Messager {
 		let body = String::new();
 		let emoji = String::new();
 
-		Self { config, commit_type_descript, typ, scope, subject, body, emoji }
+		Self { commit_type_descript, typ, scope, subject, body, emoji }
 	}
 
 	/// Load externally provided extension types.

--- a/src/message.rs
+++ b/src/message.rs
@@ -90,7 +90,7 @@ impl Messager {
 					grc_err_println(OVERWRITE_PARSE_FAILED);
 					std::process::exit(1);
 				};
-				if td.0 == arr_emo[0] {
+				if td.0 == arr_emo[0].trim() {
 					td.update_emoji(arr_emo[1].to_string());
 					return;
 				}

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,9 +1,8 @@
-
 /* -------------------------------------------------------------------------- */
 /* GRC Metadata */
 /* -------------------------------------------------------------------------- */
 
-pub const VERSION: &str = "0.9.2";
+pub const VERSION: &str = "1.0.0.beta.1";
 pub const AUTHOR: &str = "SDTTTTT. <sdttttt@outlook.com>";
 pub const NAME: &str = "GRC";
 pub const DESCRIPTION: &str = r#"
@@ -47,10 +46,10 @@ pub const BASE_COMMIT_TYPE_EMOJI: &[(&str, &str)] = &[
 	("fix", "🐞"),
 	("chore", "📦"),
 	("docs", "📝"),
-	("refactor", "✂"),
+	("refactor", "✂ "),
 	("style", "🎨"),
 	("perf", "⚡"),
-	("ci", "🚀")
+	("ci", "🚀"),
 ];
 
 /* -------------------------------------------------------------------------- */
@@ -85,7 +84,7 @@ pub const DESIGNATE_CONFIG_COMMAND_HELP: &str =
 	"Manually specify a configuration file for the GRC.";
 
 /* -------------------------------------------------------------------------- */
-/*                              CLI Enable EMOJI                              */
+/* CLI Enable EMOJI */
 /* -------------------------------------------------------------------------- */
 
 pub const EMOJI_COMMAND: &str = "emoji";

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -57,7 +57,7 @@ pub const BASE_COMMIT_TYPE_EMOJI: &[(&str, &str)] = &[
 /* GRC Commit Mode */
 /* -------------------------------------------------------------------------- */
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Mode {
 	Add,
 	AddAll,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -89,3 +89,11 @@ pub const DESIGNATE_CONFIG_COMMAND_HELP: &str =
 
 pub const EMOJI_COMMAND: &str = "emoji";
 pub const EMOJI_COMMAND_HELP: &str = "Make your submission record look beautiful.";
+
+/* -------------------------------------------------------------------------- */
+/* GRC ERROR */
+/* -------------------------------------------------------------------------- */
+
+pub const TYPE_PARSE_FAILED: &str = "Configuration File Parse Failed: ** type ** Is not correct.";
+pub const OVERWRITE_PARSE_FAILED: &str =
+	"Configuration File Parse Failed: ** overwrite_emoji ** Is not correct.";

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,3 +1,4 @@
+
 /* -------------------------------------------------------------------------- */
 /* GRC Metadata */
 /* -------------------------------------------------------------------------- */
@@ -40,11 +41,22 @@ pub const BASE_COMMIT_TYPE_DESCRIPTION: &[(&str, &str)] = &[
 	("ci", "CI related changes."),
 ];
 
+pub const BASE_COMMIT_TYPE_EMOJI: &[(&str, &str)] = &[
+	("test", "🧪"),
+	("feat", "🎉"),
+	("fix", "🐞"),
+	("chore", "📦"),
+	("docs", "📝"),
+	("refactor", "✂"),
+	("style", "🎨"),
+	("perf", "⚡"),
+	("ci", "🚀")
+];
+
 /* -------------------------------------------------------------------------- */
 /* GRC Commit Mode */
 /* -------------------------------------------------------------------------- */
 
-// GRC four commit modes.
 #[derive(Debug, PartialEq)]
 pub enum Mode {
 	Add,
@@ -71,3 +83,10 @@ pub const DESIGNATE_CONFIG_PARAMS: &str = "configfile";
 pub const DESIGNATE_CONFIG_COMMAND_SHORT: &str = "c";
 pub const DESIGNATE_CONFIG_COMMAND_HELP: &str =
 	"Manually specify a configuration file for the GRC.";
+
+/* -------------------------------------------------------------------------- */
+/*                              CLI Enable EMOJI                              */
+/* -------------------------------------------------------------------------- */
+
+pub const EMOJI_COMMAND: &str = "emoji";
+pub const EMOJI_COMMAND_HELP: &str = "Make your submission record look beautiful.";

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -15,8 +15,8 @@ use crate::{
 /// Repository in GRC.
 /// is git2::Repository Encapsulation.
 pub struct Repository {
-	repo: git2::Repository,
-	config:  Rc<Configuration>,
+	repo:   git2::Repository,
+	config: Rc<Configuration>,
 }
 
 impl Repository {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -6,7 +6,7 @@ use git2::{
 };
 
 use crate::{
-	arguments::Arguments,
+	config::Configuration,
 	log::grc_println,
 	metadata::Mode,
 	util::{author_sign_from_env, committer_sign_from_env, is_all_workspace},
@@ -16,23 +16,23 @@ use crate::{
 /// is git2::Repository Encapsulation.
 pub struct Repository {
 	repo: git2::Repository,
-	arg:  Rc<Arguments>,
+	config:  Rc<Configuration>,
 }
 
 impl Repository {
-	pub fn new(path: String, arg: Rc<Arguments>) -> Result<Self, Error> {
+	pub fn new(path: String, arg: Rc<Configuration>) -> Result<Self, Error> {
 		let result = GRepository::open(&path);
 		match result {
-			| Ok(repo) => Ok(Self { repo, arg }),
+			| Ok(repo) => Ok(Self { repo, config: arg }),
 			| Err(e) => Err(e),
 		}
 	}
 
 	/// actions before commit.
 	pub fn pre_commit(&self) -> Result<(), Error> {
-		match self.arg.command_mode() {
+		match self.config.command_mode() {
 			| Mode::Commit => self.check_index()?,
-			| Mode::Add => self.add_files(self.arg.files())?,
+			| Mode::Add => self.add_files(self.config.files())?,
 			| Mode::AddAll => self.add_all_files()?,
 		};
 
@@ -41,7 +41,7 @@ impl Repository {
 
 	/// actions after commit.
 	pub fn after_commit(&self) -> Result<(), Error> {
-		match self.arg.command_mode() {
+		match self.config.command_mode() {
 			| Mode::Commit => {}
 			| Mode::Add => {}
 			| Mode::AddAll => {}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use git2::{Error, Signature, Status, Statuses};
+use git2::{Signature, Status, Statuses};
 use std::{env, fs};
 
 use crate::metadata::{GIT_AUTHOR_EMAIL, GIT_AUTHOR_NAME, GIT_COMMITTER_EMAIL, GIT_COMMITTER_NAME};


### PR DESCRIPTION
### Feat

- support `emoji`

#### Detail

- 现在可以使用`--emoji`来强化你的`commit`消息.
- `GRC`内的基本提交类型都内置了简单的`emoji`.
- 你可以通过新的配置文件选项`overwrite_emoji`来定制你自己的定义的提交类型, 或者是覆盖`GRC`原有的基本提交类型.

#### Code

- 在代码上, 我创建了新的`Configuration`结构体, 来合并配置文件和命令行的参数选项.

---

这个版本稳定之后, 就是`GRC`的正式版了.

后期的开发方向可能会在GRC中增加提交钩子功能. 以及插件系统(主要实现一个对提交文件的风格化处理, 不修改文件.)