### PR TITLE
(cargo-release) start next development iteration 1.0.1-alpha.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "grc"
-version = "1.0.0"
+version = "1.0.1-alpha.0"
 dependencies = [
  "cargo-husky",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grc"
-version = "1.0.0"
+version = "1.0.1-alpha.0"
 authors = ["sdttttt <sdttttt@outlook.com>"]
 description = "Similar to git-cz, gcr will help you to provide a better Git experience."
 readme = "README.md"


### PR DESCRIPTION
What a hassle, the automated release has gone wrong again. I'll release it myself in the future.