### PR TITLE
to version 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,18 +40,18 @@ checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cc"
-version = "1.0.60"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 dependencies = [
  "jobserver",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -103,10 +103,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "getrandom"
-version = "0.1.15"
+name = "form_urlencoded"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if",
  "libc",
@@ -115,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.12"
+version = "0.13.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6f1a0238d7f8f8fd5ee642f4ebac4dbc03e03d1f78fbe7a3ede35dcf7e2224"
+checksum = "1d250f5f82326884bd39c2853577e70a121775db76818ffa452ed1e80de12986"
 dependencies = [
  "bitflags",
  "libc",
@@ -143,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
@@ -178,15 +188,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.77"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.14+1.1.0"
+version = "0.12.18+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f25af58e6495f7caf2919d08f212de550cfa3ed2f5e744988938ea292b9f549"
+checksum = "3da6a42da88fc37ee1ecda212ffa254c25713532980005d5f7c0b0fbe7e6e885"
 dependencies = [
  "cc",
  "libc",
@@ -198,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.19"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca46220853ba1c512fc82826d0834d87b06bcd3c2a42241b7de72f3d2fe17056"
+checksum = "e0186af0d8f171ae6b9c4c90ec51898bad5d08a2d5e470903a50d9ad8959cbee"
 dependencies = [
  "cc",
  "libc",
@@ -224,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
@@ -245,9 +255,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.58"
+version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
  "autocfg",
  "cc",
@@ -264,15 +274,15 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
@@ -285,20 +295,19 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
- "getrandom",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -307,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -317,42 +326,45 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
-version = "1.3.9"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "remove_dir_all"
@@ -365,18 +377,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -391,9 +403,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -402,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if",
  "libc",
@@ -416,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.13"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a14cd9f8c72704232f0bfc8455c0e861f0ad4eb60cc9ec8a170e231414c1e13"
+checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
 dependencies = [
  "libc",
  "winapi",
@@ -435,15 +447,24 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
@@ -459,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
  "tinyvec",
 ]
@@ -480,10 +501,11 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",
@@ -491,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec_map"
@@ -503,9 +525,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "grc"
-version = "1.0.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "cargo-husky",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "grc"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 dependencies = [
  "cargo-husky",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "grc"
-version = "1.1.0-alpha.0"
+version = "1.1.0-beta.1"
 dependencies = [
  "cargo-husky",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "grc"
-version = "1.0.0"
+version = "1.0.1-alpha.0"
 dependencies = [
  "cargo-husky",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "grc"
-version = "1.0.1-alpha.0"
+version = "1.1.0-alpha.0"
 dependencies = [
  "cargo-husky",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grc"
-version = "1.0.0"
+version = "1.0.0-rc.1"
 authors = ["sdttttt <sdttttt@outlook.com>"]
 description = "Similar to git-cz, gcr will help you to provide a better Git experience."
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grc"
-version = "1.0.0"
+version = "1.0.1-alpha.0"
 authors = ["sdttttt <sdttttt@outlook.com>"]
 description = "Similar to git-cz, gcr will help you to provide a better Git experience."
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grc"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 authors = ["sdttttt <sdttttt@outlook.com>"]
 description = "Similar to git-cz, gcr will help you to provide a better Git experience."
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grc"
-version = "1.1.0-alpha.0"
+version = "1.1.0-beta.1"
 authors = ["sdttttt <sdttttt@outlook.com>"]
 description = "Similar to git-cz, gcr will help you to provide a better Git experience."
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grc"
-version = "1.0.1-alpha.0"
+version = "1.1.0-alpha.0"
 authors = ["sdttttt <sdttttt@outlook.com>"]
 description = "Similar to git-cz, gcr will help you to provide a better Git experience."
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ overwrite_emoji = [
 ]
 ```
 
+### Plug
+
+plug are a new feature added in `1.1.0`. Details of the plug-in and usage can be found [here](https://github.com/sdttttt/gcr/tree/develop/src/plugins).
+
 ## IDEA
 
 If you have any new ideas, you are welcome to talk to me.

--- a/grc.toml
+++ b/grc.toml
@@ -1,2 +1,3 @@
 emoji = true
 type = ["version: version is change.", "deps: Dependencies change."]
+plug = ["log"]

--- a/grc.toml
+++ b/grc.toml
@@ -1,3 +1,3 @@
 emoji = true
 type = ["version: version is change.", "deps: Dependencies change."]
-plug = ["log"]
+plug = ["push"]

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ g = grc
 
 .PHONY: build
 build: fmt
-	$(c) build --release
+	$(c) build --release -v
 
 .PHONY: run
 run: fmt

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,14 +1,20 @@
 use std::rc::Rc;
 
-use crate::{arguments::Arguments, extensions::Extensions, metadata::Mode};
+use crate::{
+	arguments::Arguments,
+	extensions::Extensions,
+	metadata::Mode,
+	plugins::{find_plug, CommitPlugin},
+};
 
-// Both command-line arguments and configuration files can specify
-// configuration. options, and the two are combined here.
+// Both command-line arguments and configuration files can specify configuration
+// options, and the two are combined here.
 pub struct Configuration {
 	mode:            Mode,
 	extends_type:    Vec<String>,
 	params:          Vec<String>,
 	overwrite_emoji: Vec<String>,
+	plugs:           Vec<Rc<dyn CommitPlugin>>,
 	emoji:           bool,
 }
 
@@ -21,7 +27,9 @@ impl Configuration {
 		let overwrite_emoji =
 			if emoji { ext.overwrite_emoji().unwrap_or(&vec![]).clone() } else { vec![] };
 
-		Rc::new(Self { params, extends_type, emoji, mode, overwrite_emoji })
+		let plugs = find_plug(ext.plug().unwrap_or(&vec![]));
+
+		Rc::new(Self { params, extends_type, emoji, mode, overwrite_emoji, plugs })
 	}
 
 	//#[cfg(test)]
@@ -50,5 +58,9 @@ impl Configuration {
 
 	pub fn overwrite_emoji(&self) -> &Vec<String> {
 		&self.overwrite_emoji
+	}
+
+	pub fn plugins(&self) -> &Vec<Rc<dyn CommitPlugin>> {
+		&self.plugs
 	}
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,8 +2,8 @@ use std::rc::Rc;
 
 use crate::{arguments::Arguments, extensions::Extensions, metadata::Mode};
 
-// Both command-line arguments and configuration files can specify configuration
-// options, and the two are combined here.
+// Both command-line arguments and configuration files can specify
+// configuration. options, and the two are combined here.
 pub struct Configuration {
 	mode:            Mode,
 	extends_type:    Vec<String>,

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -15,6 +15,7 @@ pub struct Extensions {
 	emoji: Option<bool>,
 
 	overwrite_emoji: Option<Vec<String>>,
+	plug:            Option<Vec<String>>,
 }
 
 impl Extensions {
@@ -61,6 +62,10 @@ impl Extensions {
 		self.overwrite_emoji.as_ref()
 	}
 
+	pub fn plug(&self) -> Option<&Vec<String>> {
+		self.plug.as_ref()
+	}
+
 	/// deserialize toml configuration file to struct.
 	fn deserialize(file_str: String) -> Result<Self, Error> {
 		if file_str.len() == 0 || file_str == "" {
@@ -68,6 +73,7 @@ impl Extensions {
 				typ:             None,
 				emoji:           None,
 				overwrite_emoji: None,
+				plug:            None,
 			});
 		}
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -4,7 +4,7 @@ use console::Style;
 
 /// GCR logger.
 pub fn grc_println(content: impl Display) {
-	println!("GRC: {}", content)
+	println!("{}", content)
 }
 
 /// GCR error logger.
@@ -16,12 +16,12 @@ pub fn grc_err_println(content: impl Display) {
 }
 
 /// GCR error logger.
-//pub fn grc_warn_println(content: impl Display) {
-//	let color = Style::new().yellow();
-//	let output = format!("GRC: {}", content);
+pub fn grc_warn_println(content: impl Display) {
+	let color = Style::new().yellow();
+	let output = format!("GRC: {}", content);
 
-//	println!("{}", color.apply_to(output))
-//}
+	println!("{}", color.apply_to(output))
+}
 
 #[cfg(test)]
 mod tests {
@@ -36,5 +36,10 @@ mod tests {
 	#[test]
 	fn it_grc_err_println() {
 		grc_err_println("TEST ERROR CONTENT.");
+	}
+
+	#[test]
+	fn it_grc_warn_println() {
+		grc_warn_println("TEST WARN CONTENT.");
 	}
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -10,17 +10,15 @@ pub fn grc_println(content: impl Display) {
 /// GCR error logger.
 pub fn grc_err_println(content: impl Display) {
 	let color = Style::new().red();
-	let output = format!("GRC: {}", content);
 
-	println!("{}", color.apply_to(output))
+	println!("{}", color.apply_to(content))
 }
 
 /// GCR error logger.
 pub fn grc_warn_println(content: impl Display) {
 	let color = Style::new().yellow();
-	let output = format!("GRC: {}", content);
 
-	println!("{}", color.apply_to(output))
+	println!("{}", color.apply_to(content))
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod extensions;
 mod log;
 mod message;
 mod metadata;
+mod plugins;
 mod repo;
 mod util;
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -202,7 +202,7 @@ impl Messager {
 			})
 			.interact()
 			.unwrap();
-		
+
 		if !self.emoji.is_empty() {
 			self.subject = format!("{} {}", self.emoji, self.subject)
 		}

--- a/src/message.rs
+++ b/src/message.rs
@@ -202,8 +202,10 @@ impl Messager {
 			})
 			.interact()
 			.unwrap();
-
-		self.subject = format!("{} {}", self.emoji, self.subject)
+		
+		if !self.emoji.is_empty() {
+			self.subject = format!("{} {}", self.emoji, self.subject)
+		}
 	}
 
 	/// description of commit message.

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -2,7 +2,7 @@
 /* GRC Metadata */
 /* -------------------------------------------------------------------------- */
 
-pub const VERSION: &str = "1.0.0.beta.1";
+pub const VERSION: &str = "1.1.0-alpha.0";
 pub const AUTHOR: &str = "SDTTTTT. <sdttttt@outlook.com>";
 pub const NAME: &str = "GRC";
 pub const DESCRIPTION: &str = r#"

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -2,7 +2,7 @@
 /* GRC Metadata */
 /* -------------------------------------------------------------------------- */
 
-pub const VERSION: &str = "1.1.0-alpha.0";
+pub const VERSION: &str = "1.1.0-beta.1";
 pub const AUTHOR: &str = "SDTTTTT. <sdttttt@outlook.com>";
 pub const NAME: &str = "GRC";
 pub const DESCRIPTION: &str = r#"

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -1,0 +1,43 @@
+# Plug
+
+This is where all of GRC's built-in plugins are available.
+The lifecycle of plug-in execution occurs before and after GRC `Commit`.
+
+Currently, GRC provides very simple lifecycle hook functions.
+
+Let's take a look at these plugins:
+
+## Push
+
+Maybe you're tired of pushing after each commit. Luck ~ **push** plug-in can take care of that.
+
+This action occurs **after** the GRC completes the **commit**.
+
+Push's job is **simple**.
+
+- First, reads the name of the current branch.
+- Then find the remote link (example: `origin`) corresponding to this branch.
+- Read `$HOME/.ssh/id_rsa` from your user folder.
+- finally push to the remote branch.
+
+There are two things to note about this process:
+
+- You need ssh-key. In other words, Push requires you to use SSH as validation. (Do not use password authentication)
+- The whole push needs to be `fast-forward`.
+
+> Because `push plug-in` has no way to deal with complex situations. If there is a **branch conflict** or **inconsistent commit record**, you need to resolve it yourself.
+
+In the end, all you need is to **enable** it:
+
+```toml
+# grc.toml
+plug = ["push"]
+```
+
+
+# Contribution
+
+plug-in access is a difficult task.
+How to have a good design? highly flexible interface and strong expansibility all need to be carefully considered.
+If you have any good ideas, you are welcome to make issue or PR.
+

--- a/src/plugins/log.rs
+++ b/src/plugins/log.rs
@@ -1,0 +1,26 @@
+use std::fmt::Error;
+
+use crate::repo::Repository;
+
+use super::CommitPlugin;
+
+#[derive(Clone, Copy)]
+pub struct LogPlugin;
+
+impl LogPlugin {
+	pub fn new() -> impl CommitPlugin {
+		Self {}
+	}
+}
+
+impl CommitPlugin for LogPlugin {
+	fn before(&self, _: &Repository, _: &String) -> Option<Error> {
+		println!("log plugin runing.");
+		None
+	}
+
+	fn after(&self, _: &Repository, _: &String) -> Option<Error> {
+		println!("log plugin runing.");
+		None
+	}
+}

--- a/src/plugins/log.rs
+++ b/src/plugins/log.rs
@@ -14,12 +14,12 @@ impl LogPlugin {
 }
 
 impl CommitPlugin for LogPlugin {
-	fn before(&self, _: &Repository) ->  Result<(), Error> {
+	fn before(&self, _: &Repository) -> Result<(), Error> {
 		println!("log plugin runing.");
 		Ok(())
 	}
 
-	fn after(&self, _: &Repository) ->  Result<(), Error> {
+	fn after(&self, _: &Repository) -> Result<(), Error> {
 		println!("log plugin runing.");
 		Ok(())
 	}

--- a/src/plugins/log.rs
+++ b/src/plugins/log.rs
@@ -1,4 +1,4 @@
-use std::fmt::Error;
+use git2::Error;
 
 use crate::repo::Repository;
 
@@ -14,12 +14,12 @@ impl LogPlugin {
 }
 
 impl CommitPlugin for LogPlugin {
-	fn before(&self, _: &Repository, _: &String) -> Option<Error> {
+	fn before(&self, _: &Repository) -> Option<Error> {
 		println!("log plugin runing.");
 		None
 	}
 
-	fn after(&self, _: &Repository, _: &String) -> Option<Error> {
+	fn after(&self, _: &Repository) -> Option<Error> {
 		println!("log plugin runing.");
 		None
 	}

--- a/src/plugins/log.rs
+++ b/src/plugins/log.rs
@@ -14,13 +14,13 @@ impl LogPlugin {
 }
 
 impl CommitPlugin for LogPlugin {
-	fn before(&self, _: &Repository) -> Option<Error> {
+	fn before(&self, _: &Repository) ->  Result<(), Error> {
 		println!("log plugin runing.");
-		None
+		Ok(())
 	}
 
-	fn after(&self, _: &Repository) -> Option<Error> {
+	fn after(&self, _: &Repository) ->  Result<(), Error> {
 		println!("log plugin runing.");
-		None
+		Ok(())
 	}
 }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,0 +1,31 @@
+use std::fmt::Error;
+use std::rc::Rc;
+
+use crate::repo::Repository;
+
+mod log;
+mod push;
+
+use log::LogPlugin;
+use push::PushPlugin;
+
+pub trait CommitPlugin {
+	fn before(&self, repo: &Repository, msg: &String) -> Option<Error>;
+	fn after(&self, repo: &Repository, msg: &String) -> Option<Error>;
+}
+
+pub fn find_plug(plug_names: &Vec<String>) -> Vec<Rc<dyn CommitPlugin>> {
+	let plugin_all: &[(&str, Rc<dyn CommitPlugin>); 2] =
+		&[("log", Rc::new(LogPlugin::new())), ("push", Rc::new(PushPlugin::new()))];
+
+	let mut plugs = vec![];
+	for name in plug_names {
+		for plug in plugin_all {
+			if name.as_str() == plug.0 {
+				plugs.push(Rc::clone(&plug.1));
+			}
+		}
+	}
+
+	plugs
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -10,8 +10,13 @@ use log::LogPlugin;
 use push::PushPlugin;
 
 pub trait CommitPlugin {
-	fn before(&self, repo: &Repository) -> Option<Error>;
-	fn after(&self, repo: &Repository) -> Option<Error>;
+	fn before(&self, _: &Repository) -> Result<(), Error> {
+		Ok(())
+	}
+
+	fn after(&self, _: &Repository) -> Result<(), Error> {
+		Ok(())
+	}
 }
 
 pub fn find_plug(plug_names: &Vec<String>) -> Vec<Rc<dyn CommitPlugin>> {

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,4 +1,4 @@
-use std::fmt::Error;
+use git2::Error;
 use std::rc::Rc;
 
 use crate::repo::Repository;
@@ -10,8 +10,8 @@ use log::LogPlugin;
 use push::PushPlugin;
 
 pub trait CommitPlugin {
-	fn before(&self, repo: &Repository, msg: &String) -> Option<Error>;
-	fn after(&self, repo: &Repository, msg: &String) -> Option<Error>;
+	fn before(&self, repo: &Repository) -> Option<Error>;
+	fn after(&self, repo: &Repository) -> Option<Error>;
 }
 
 pub fn find_plug(plug_names: &Vec<String>) -> Vec<Rc<dyn CommitPlugin>> {

--- a/src/plugins/push.rs
+++ b/src/plugins/push.rs
@@ -1,4 +1,4 @@
-use git2::Error;
+	use git2::{Error, Direction};
 
 use crate::repo::Repository;
 
@@ -14,13 +14,13 @@ impl PushPlugin {
 }
 
 impl CommitPlugin for PushPlugin {
-	fn before(&self, _: &Repository) -> Option<Error> {
-		println!("log plugin runing.");
-		None
-	}
 
-	fn after(&self, _: &Repository) -> Option<Error> {
-		println!("log plugin runing.");
-		None
+	fn after(&self, repo: &Repository) ->  Result<(), Error> {
+		println!("[+] running push ...");
+		let real_repo = repo.real_repo();
+		let mut remote = real_repo.find_remote("origin")?;
+		remote.connect(Direction::Push)?;
+		remote.push(&[""], None)?;
+		Ok(())
 	}
 }

--- a/src/plugins/push.rs
+++ b/src/plugins/push.rs
@@ -1,4 +1,4 @@
-use std::fmt::Error;
+use git2::Error;
 
 use crate::repo::Repository;
 
@@ -14,12 +14,12 @@ impl PushPlugin {
 }
 
 impl CommitPlugin for PushPlugin {
-	fn before(&self, _: &Repository, _: &String) -> Option<Error> {
+	fn before(&self, _: &Repository) -> Option<Error> {
 		println!("log plugin runing.");
 		None
 	}
 
-	fn after(&self, _: &Repository, _: &String) -> Option<Error> {
+	fn after(&self, _: &Repository) -> Option<Error> {
 		println!("log plugin runing.");
 		None
 	}

--- a/src/plugins/push.rs
+++ b/src/plugins/push.rs
@@ -22,9 +22,9 @@ impl CommitPlugin for PushPlugin {
 		let head = real_repo.head().unwrap();
 		let branch_name = head.shorthand().unwrap_or_else(|| "");
 		let config = real_repo.config()?;
-		let remote_name = config.get_str(format!("branch.{}.remote", branch_name).as_str())?;
+		let remote_name = config.get_string(format!("branch.{}.remote", branch_name).as_str())?;
 
-		let mut remote = real_repo.find_remote(remote_name)?;
+		let mut remote = real_repo.find_remote(remote_name.as_str())?;
 		let mut callbacks = RemoteCallbacks::new();
 		callbacks.credentials(|_, username_from_url, _| {
 			Cred::ssh_key(
@@ -48,3 +48,26 @@ impl CommitPlugin for PushPlugin {
 		Ok(())
 	}
 }
+
+//#[cfg(test)]
+//mod tests {
+//	use git2::Repository;
+
+//	#[test]
+//	fn it_remote_name() {
+//		let repo = Repository::open(".").unwrap();
+//		let config = repo.config().unwrap();
+//		let remote_name = config.get_string("branch.develop.remote").unwrap();
+
+//		assert_eq!("origin", remote_name.as_str());
+//	}
+
+//	#[test]
+//	fn it_branch_name() {
+//		let repo = Repository::open(".").unwrap();
+//		let head = repo.head().unwrap();
+//		let branch_name = head.shorthand().unwrap_or_else(|| "");
+
+//		assert_eq!("develop", branch_name);
+//	}
+//}

--- a/src/plugins/push.rs
+++ b/src/plugins/push.rs
@@ -1,6 +1,7 @@
-	use git2::{Error, Direction};
-
 use crate::repo::Repository;
+use git2::{Cred, Direction, Error, PushOptions, RemoteCallbacks};
+use std::env;
+use std::path::Path;
 
 use super::CommitPlugin;
 
@@ -14,13 +15,31 @@ impl PushPlugin {
 }
 
 impl CommitPlugin for PushPlugin {
-
-	fn after(&self, repo: &Repository) ->  Result<(), Error> {
+	fn after(&self, repo: &Repository) -> Result<(), Error> {
 		println!("[+] running push ...");
 		let real_repo = repo.real_repo();
+
+		let head = real_repo.head()?;
+		let head = head.shorthand().unwrap_or_else(|| "");
+
 		let mut remote = real_repo.find_remote("origin")?;
-		remote.connect(Direction::Push)?;
-		remote.push(&[""], None)?;
+		let mut callbacks = RemoteCallbacks::new();
+		callbacks.credentials(|_, username_from_url, _| {
+			Cred::ssh_key(
+				username_from_url.unwrap(),
+				None,
+				Path::new(&format!("{}/.ssh/id_rsa", env::var("HOME").unwrap())),
+				None,
+			)
+		});
+
+		let mut push_option: PushOptions = PushOptions::new();
+		push_option.remote_callbacks(callbacks);
+
+		remote.push(
+			&[format!("refs/heads/{}:refs/heads/{}", head, head).as_str()],
+			Some(&mut push_option),
+		)?;
 		Ok(())
 	}
 }

--- a/src/plugins/push.rs
+++ b/src/plugins/push.rs
@@ -1,5 +1,5 @@
 use crate::repo::Repository;
-use git2::{Cred, Direction, Error, PushOptions, RemoteCallbacks};
+use git2::{Cred, Error, PushOptions, RemoteCallbacks};
 use std::env;
 use std::path::Path;
 

--- a/src/plugins/push.rs
+++ b/src/plugins/push.rs
@@ -1,0 +1,26 @@
+use std::fmt::Error;
+
+use crate::repo::Repository;
+
+use super::CommitPlugin;
+
+#[derive(Clone, Copy)]
+pub struct PushPlugin;
+
+impl PushPlugin {
+	pub fn new() -> impl CommitPlugin {
+		Self {}
+	}
+}
+
+impl CommitPlugin for PushPlugin {
+	fn before(&self, _: &Repository, _: &String) -> Option<Error> {
+		println!("log plugin runing.");
+		None
+	}
+
+	fn after(&self, _: &Repository, _: &String) -> Option<Error> {
+		println!("log plugin runing.");
+		None
+	}
+}

--- a/src/plugins/push.rs
+++ b/src/plugins/push.rs
@@ -1,4 +1,4 @@
-use crate::repo::Repository;
+use crate::{log::grc_warn_println, repo::Repository};
 use git2::{Cred, Error, PushOptions, RemoteCallbacks};
 use std::env;
 use std::path::Path;
@@ -16,7 +16,7 @@ impl PushPlugin {
 
 impl CommitPlugin for PushPlugin {
 	fn after(&self, repo: &Repository) -> Result<(), Error> {
-		println!("[+] running push ...");
+		println!("[*] running push ...");
 		let real_repo = repo.real_repo();
 
 		let head = real_repo.head()?;
@@ -35,6 +35,8 @@ impl CommitPlugin for PushPlugin {
 
 		let mut push_option: PushOptions = PushOptions::new();
 		push_option.remote_callbacks(callbacks);
+
+		grc_warn_println(format!("Target Branch: {}", head));
 
 		remote.push(
 			&[format!("refs/heads/{}:refs/heads/{}", head, head).as_str()],

--- a/src/plugins/push.rs
+++ b/src/plugins/push.rs
@@ -1,8 +1,8 @@
 use crate::{log::grc_warn_println, repo::Repository};
+use console::Style;
 use git2::{Cred, Error, PushOptions, RemoteCallbacks};
 use std::env;
 use std::path::Path;
-use console::Style;
 
 use super::CommitPlugin;
 

--- a/src/plugins/push.rs
+++ b/src/plugins/push.rs
@@ -2,6 +2,7 @@ use crate::{log::grc_warn_println, repo::Repository};
 use git2::{Cred, Error, PushOptions, RemoteCallbacks};
 use std::env;
 use std::path::Path;
+use console::Style;
 
 use super::CommitPlugin;
 
@@ -16,7 +17,7 @@ impl PushPlugin {
 
 impl CommitPlugin for PushPlugin {
 	fn after(&self, repo: &Repository) -> Result<(), Error> {
-		println!("[*] running push ...");
+		println!("[{}] running push ...", Style::new().yellow().apply_to("-"));
 		let real_repo = repo.real_repo();
 
 		let head = real_repo.head().unwrap();
@@ -45,6 +46,8 @@ impl CommitPlugin for PushPlugin {
 			&[format!("refs/heads/{}:refs/heads/{}", branch_name, branch_name).as_str()],
 			Some(&mut push_option),
 		)?;
+
+		println!("[{}] push is end.", Style::new().green().apply_to("~"));
 		Ok(())
 	}
 }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -70,7 +70,7 @@ impl Repository {
 
 		for plug in self.config.plugins() {
 			plug.before(&self)?;
-		};
+		}
 
 		Ok(())
 	}
@@ -85,11 +85,10 @@ impl Repository {
 
 		for plug in self.config.plugins() {
 			plug.after(&self)?;
-		};
+		}
 
 		Ok(())
 	}
-
 
 	/// Repository status.
 	fn status(&self) -> Result<Statuses<'_>, Error> {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -12,18 +12,22 @@ use crate::{
 	util::{author_sign_from_env, committer_sign_from_env, is_all_workspace},
 };
 
+// GRC ACTION HOOK.
+// To reduce complexity, this hook does not change the GRC's original behavior.
+pub type CommitHook = fn(&Repository, &String) -> Option<Error>;
+
 /// Repository in GRC.
 /// is git2::Repository Encapsulation.
 pub struct Repository {
-	repo:   git2::Repository,
+	repo:   GRepository,
 	config: Rc<Configuration>,
 }
 
 impl Repository {
-	pub fn new(path: String, arg: Rc<Configuration>) -> Result<Self, Error> {
+	pub fn new(path: String, config: Rc<Configuration>) -> Result<Self, Error> {
 		let result = GRepository::open(&path);
 		match result {
-			| Ok(repo) => Ok(Self { repo, config: arg }),
+			| Ok(repo) => Ok(Self { repo, config }),
 			| Err(e) => Err(e),
 		}
 	}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use git2::{Signature, Status, Statuses};
+use git2::{Repository, Signature, Status, Statuses};
 use std::{env, fs};
 
 use crate::metadata::{GIT_AUTHOR_EMAIL, GIT_AUTHOR_NAME, GIT_COMMITTER_EMAIL, GIT_COMMITTER_NAME};

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use git2::{Repository, Signature, Status, Statuses};
+use git2::{Signature, Status, Statuses};
 use std::{env, fs};
 
 use crate::metadata::{GIT_AUTHOR_EMAIL, GIT_AUTHOR_NAME, GIT_COMMITTER_EMAIL, GIT_COMMITTER_NAME};


### PR DESCRIPTION
🎉 A surprise! GRC **1.1.0** is coming soon.

This release has some exciting features. We have added a plug-in module to GRC in this release. The plugins currently available are:


- **push plugin** (grc will automatically commit to the remote branch (**origin**) corresponding to the name after the submission is completed. `push plugin` cannot handle **complex** behavior. *idea: @idiotc4t*)

Now, there is nothing more yet. **qaq**

If you need to **enable** the appropriate **plug-in**, just add the corresponding option to `grc.toml`

```toml
plug = [ "push" ]
```

### Fix

- grc could not be commit for the first time in the new init repository. #44 